### PR TITLE
Implement RISC-V AIA CSR register modules

### DIFF
--- a/library/riscv-aia/src/lib.rs
+++ b/library/riscv-aia/src/lib.rs
@@ -57,3 +57,16 @@ impl Iid {
         self.number.get()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn iid_new_bounds() {
+        assert!(Iid::new(0).is_none());
+        assert!(Iid::new(1).is_some());
+        assert!(Iid::new(2047).is_some());
+        assert!(Iid::new(2048).is_none());
+    }
+}

--- a/library/riscv-aia/src/register.rs
+++ b/library/riscv-aia/src/register.rs
@@ -3,63 +3,63 @@
 // -- `Smaia` CSRs --
 
 // Machine-level window to indirectly accessed registers
-// TODO pub mod miselect;
-// TODO pub mod mireg;
+pub mod miselect;
+pub mod mireg;
 
 // Machine-level interrupts
-// TODO pub mod mie;
-// TODO pub mod mip;
+pub mod mie;
+pub mod mip;
 pub mod mtopei;
 pub mod mtopi;
 
 // Machine-level high-half CSRs, RV32 only.
 pub mod midelegh;
-// TODO pub mod mieh;
-// TODO pub mod miph;
-// TODO pub mod mvieh;
-// TODO pub mod mviph;
+pub mod mieh;
+pub mod miph;
+pub mod mvieh;
+pub mod mviph;
 
 // -- `Ssaia` CSRs --
 
 // Supervisor-level window to indirectly accessed registers
-// TODO pub mod siselect;
-// TODO pub mod sireg;
+pub mod siselect;
+pub mod sireg;
 
 // Supervisor-level interrupts
-// TODO pub mod sie;
-// TODO pub mod sip;
-// TODO pub mod stopei;
-// TODO pub mod stopi;
+pub mod sie;
+pub mod sip;
+pub mod stopei;
+pub mod stopi;
 
 // Supervisor-level high-half CSRs, RV32 only.
-// TODO pub mod sieh;
-// TODO pub mod siph;
+pub mod sieh;
+pub mod siph;
 
 // -- Hypervisor and VS CSRs --
 
 // Delegated and virtual interrupts, interrupt priorities, for VS-level
-// TODO pub mod hideleg;
-// TODO pub mod hvien;
-// TODO pub mod hvictl;
-// TODO pub mod hvip;
-// TODO pub mod hviprio1;
-// TODO pub mod hviprio2;
+pub mod hideleg;
+pub mod hvien;
+pub mod hvictl;
+pub mod hvip;
+pub mod hviprio1;
+pub mod hviprio2;
 
 // VS-level window to indirectly accessed registers
-// TODO pub mod vsiselect;
-// TODO pub mod vsireg;
+pub mod vsiselect;
+pub mod vsireg;
 
 // VS-level interrupts
-// TODO pub mod vsie;
-// TODO pub mod vsip;
-// TODO pub mod vstopei;
-// TODO pub mod vstopi;
+pub mod vsie;
+pub mod vsip;
+pub mod vstopei;
+pub mod vstopi;
 
 // Hypervisor and VS-level high-half CSRs, RV32 only.
-// TODO pub mod hidelegh;
-// TODO pub mod hvienh;
-// TODO pub mod hviph;
-// TODO pub mod hviprio1h;
-// TODO pub mod hviprio2h;
-// TODO pub mod vsieh;
-// TODO pub mod vsiph;
+pub mod hidelegh;
+pub mod hvienh;
+pub mod hviph;
+pub mod hviprio1h;
+pub mod hviprio2h;
+pub mod vsieh;
+pub mod vsiph;

--- a/library/riscv-aia/src/register.rs
+++ b/library/riscv-aia/src/register.rs
@@ -9,6 +9,7 @@ pub mod mireg;
 // Machine-level interrupts
 pub mod mie;
 pub mod mip;
+pub mod mideleg;
 pub mod mtopei;
 pub mod mtopi;
 

--- a/library/riscv-aia/src/register.rs
+++ b/library/riscv-aia/src/register.rs
@@ -3,13 +3,13 @@
 // -- `Smaia` CSRs --
 
 // Machine-level window to indirectly accessed registers
-pub mod miselect;
 pub mod mireg;
+pub mod miselect;
 
 // Machine-level interrupts
+pub mod mideleg;
 pub mod mie;
 pub mod mip;
-pub mod mideleg;
 pub mod mtopei;
 pub mod mtopi;
 
@@ -23,8 +23,8 @@ pub mod mviph;
 // -- `Ssaia` CSRs --
 
 // Supervisor-level window to indirectly accessed registers
-pub mod siselect;
 pub mod sireg;
+pub mod siselect;
 
 // Supervisor-level interrupts
 pub mod sie;
@@ -40,15 +40,15 @@ pub mod siph;
 
 // Delegated and virtual interrupts, interrupt priorities, for VS-level
 pub mod hideleg;
-pub mod hvien;
 pub mod hvictl;
+pub mod hvien;
 pub mod hvip;
 pub mod hviprio1;
 pub mod hviprio2;
 
 // VS-level window to indirectly accessed registers
-pub mod vsiselect;
 pub mod vsireg;
+pub mod vsiselect;
 
 // VS-level interrupts
 pub mod vsie;

--- a/library/riscv-aia/src/register/hideleg.rs
+++ b/library/riscv-aia/src/register/hideleg.rs
@@ -25,3 +25,22 @@ impl Hideleg {
     #[inline]
     pub const fn seip(self) -> bool { self.bit(9) }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::register::mideleg::Mideleg;
+
+    #[test]
+    fn mideleg_hideleg_bits() {
+        let bits: usize = (1usize << 1) | (1usize << 5) | (1usize << 9);
+        let md = Mideleg::from_bits(bits);
+        let hd = Hideleg::from_bits(bits);
+        assert!(md.ssip());
+        assert!(md.stip());
+        assert!(md.seip());
+        assert!(hd.ssip());
+        assert!(hd.stip());
+        assert!(hd.seip());
+    }
+}

--- a/library/riscv-aia/src/register/hideleg.rs
+++ b/library/riscv-aia/src/register/hideleg.rs
@@ -15,15 +15,21 @@ impl Hideleg {
 
     /// Supervisor software interrupt delegation (bit 1).
     #[inline]
-    pub const fn ssip(self) -> bool { self.bit(1) }
+    pub const fn ssip(self) -> bool {
+        self.bit(1)
+    }
 
     /// Supervisor timer interrupt delegation (bit 5).
     #[inline]
-    pub const fn stip(self) -> bool { self.bit(5) }
+    pub const fn stip(self) -> bool {
+        self.bit(5)
+    }
 
     /// Supervisor external interrupt delegation (bit 9).
     #[inline]
-    pub const fn seip(self) -> bool { self.bit(9) }
+    pub const fn seip(self) -> bool {
+        self.bit(9)
+    }
 }
 
 #[cfg(test)]

--- a/library/riscv-aia/src/register/hideleg.rs
+++ b/library/riscv-aia/src/register/hideleg.rs
@@ -1,0 +1,7 @@
+//! Hypervisor interrupt delegation (hideleg)
+
+riscv::read_write_csr! {
+    /// Hypervisor interrupt delegation.
+    Hideleg: 0x603,
+    mask: 0xFFFF_FFFF_FFFF_FFFF,
+}

--- a/library/riscv-aia/src/register/hideleg.rs
+++ b/library/riscv-aia/src/register/hideleg.rs
@@ -5,3 +5,23 @@ riscv::read_write_csr! {
     Hideleg: 0x603,
     mask: 0xFFFF_FFFF_FFFF_FFFF,
 }
+
+impl Hideleg {
+    /// Test bit `n` of `hideleg` (generic helper).
+    #[inline]
+    pub const fn bit(self, n: usize) -> bool {
+        ((self.bits >> n) & 1) != 0
+    }
+
+    /// Supervisor software interrupt delegation (bit 1).
+    #[inline]
+    pub const fn ssip(self) -> bool { self.bit(1) }
+
+    /// Supervisor timer interrupt delegation (bit 5).
+    #[inline]
+    pub const fn stip(self) -> bool { self.bit(5) }
+
+    /// Supervisor external interrupt delegation (bit 9).
+    #[inline]
+    pub const fn seip(self) -> bool { self.bit(9) }
+}

--- a/library/riscv-aia/src/register/hidelegh.rs
+++ b/library/riscv-aia/src/register/hidelegh.rs
@@ -11,3 +11,15 @@ impl Hidelegh {
     #[inline]
     pub const fn raw(self) -> usize { self.bits }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn hidelegh_raw_roundtrip() {
+        let bits: usize = 0xDEAD_BEEFusize & 0xFFFF_FFFF;
+        let reg = Hidelegh::from_bits(bits);
+        assert_eq!(reg.raw(), bits);
+    }
+}

--- a/library/riscv-aia/src/register/hidelegh.rs
+++ b/library/riscv-aia/src/register/hidelegh.rs
@@ -9,7 +9,9 @@ riscv::read_write_csr! {
 impl Hidelegh {
     /// Raw 32-bit value of `hidelegh`.
     #[inline]
-    pub const fn raw(self) -> usize { self.bits }
+    pub const fn raw(self) -> usize {
+        self.bits
+    }
 }
 
 #[cfg(test)]

--- a/library/riscv-aia/src/register/hidelegh.rs
+++ b/library/riscv-aia/src/register/hidelegh.rs
@@ -1,0 +1,7 @@
+//! Hypervisor interrupt delegation high-half (hidelegh) (RV32 only)
+
+riscv::read_write_csr! {
+    /// Upper 32 bits of hideleg.
+    Hidelegh: 0x613,
+    mask: 0xFFFF_FFFF,
+}

--- a/library/riscv-aia/src/register/hidelegh.rs
+++ b/library/riscv-aia/src/register/hidelegh.rs
@@ -5,3 +5,9 @@ riscv::read_write_csr! {
     Hidelegh: 0x613,
     mask: 0xFFFF_FFFF,
 }
+
+impl Hidelegh {
+    /// Raw 32-bit value of `hidelegh`.
+    #[inline]
+    pub const fn raw(self) -> usize { self.bits }
+}

--- a/library/riscv-aia/src/register/hvictl.rs
+++ b/library/riscv-aia/src/register/hvictl.rs
@@ -46,7 +46,8 @@ mod tests {
     #[test]
     fn hvictl_fields() {
         // Set vti (bit 30), iid=0x123 (bits 27:16), dpr (bit 9), ipriom (bit 8), iprio=0xAB (bits 7:0)
-        let bits: usize = (1usize << 30) | (0x123usize << 16) | (1usize << 9) | (1usize << 8) | 0xAB;
+        let bits: usize =
+            (1usize << 30) | (0x123usize << 16) | (1usize << 9) | (1usize << 8) | 0xAB;
         let reg = Hvictl::from_bits(bits);
         assert!(reg.vti());
         assert_eq!(reg.iid().map(|i| i.number()), Some(0x123));

--- a/library/riscv-aia/src/register/hvictl.rs
+++ b/library/riscv-aia/src/register/hvictl.rs
@@ -38,3 +38,31 @@ impl Hvictl {
         (self.bits & 0xFF) as u8
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn hvictl_fields() {
+        // Set vti (bit 30), iid=0x123 (bits 27:16), dpr (bit 9), ipriom (bit 8), iprio=0xAB (bits 7:0)
+        let bits: usize = (1usize << 30) | (0x123usize << 16) | (1usize << 9) | (1usize << 8) | 0xAB;
+        let reg = Hvictl::from_bits(bits);
+        assert!(reg.vti());
+        assert_eq!(reg.iid().map(|i| i.number()), Some(0x123));
+        assert!(reg.dpr());
+        assert!(reg.ipriom());
+        assert_eq!(reg.iprio(), 0xAB);
+    }
+
+    #[test]
+    fn hvictl_zero_iid() {
+        let bits: usize = 0;
+        let reg = Hvictl::from_bits(bits);
+        assert!(!reg.vti());
+        assert!(reg.iid().is_none());
+        assert!(!reg.dpr());
+        assert!(!reg.ipriom());
+        assert_eq!(reg.iprio(), 0);
+    }
+}

--- a/library/riscv-aia/src/register/hvictl.rs
+++ b/library/riscv-aia/src/register/hvictl.rs
@@ -5,3 +5,36 @@ riscv::read_write_csr! {
     Hvictl: 0x609,
     mask: 0xFFFF_FFFF_FFFF_FFFF,
 }
+
+impl Hvictl {
+    /// Virtual Trap Interrupt (VTI) bit (bit 30).
+    #[inline]
+    pub const fn vti(self) -> bool {
+        ((self.bits >> 30) & 1) != 0
+    }
+
+    /// IID field (bits 27:16) — interrupt identity for a virtual interrupt.
+    #[inline]
+    pub const fn iid(self) -> Option<crate::Iid> {
+        let bits = ((self.bits >> 16) & 0x0FFF) as u16;
+        crate::Iid::new(bits)
+    }
+
+    /// Default Priority Rank (DPR) bit (bit 9).
+    #[inline]
+    pub const fn dpr(self) -> bool {
+        ((self.bits >> 9) & 1) != 0
+    }
+
+    /// IPRIO mode bit (bit 8).
+    #[inline]
+    pub const fn ipriom(self) -> bool {
+        ((self.bits >> 8) & 1) != 0
+    }
+
+    /// IPRIO field (bits 7:0).
+    #[inline]
+    pub const fn iprio(self) -> u8 {
+        (self.bits & 0xFF) as u8
+    }
+}

--- a/library/riscv-aia/src/register/hvictl.rs
+++ b/library/riscv-aia/src/register/hvictl.rs
@@ -1,0 +1,7 @@
+//! Hypervisor virtual interrupt control (hvictl)
+
+riscv::read_write_csr! {
+    /// Hypervisor virtual interrupt control.
+    Hvictl: 0x609,
+    mask: 0xFFFF_FFFF_FFFF_FFFF,
+}

--- a/library/riscv-aia/src/register/hvien.rs
+++ b/library/riscv-aia/src/register/hvien.rs
@@ -14,15 +14,21 @@ impl Hvien {
 
     /// VS-level software interrupt enable (bit 2).
     #[inline]
-    pub const fn vssip(self) -> bool { self.bit(2) }
+    pub const fn vssip(self) -> bool {
+        self.bit(2)
+    }
 
     /// VS-level timer interrupt enable (bit 6).
     #[inline]
-    pub const fn vstip(self) -> bool { self.bit(6) }
+    pub const fn vstip(self) -> bool {
+        self.bit(6)
+    }
 
     /// VS-level external interrupt enable (bit 10).
     #[inline]
-    pub const fn vseip(self) -> bool { self.bit(10) }
+    pub const fn vseip(self) -> bool {
+        self.bit(10)
+    }
 }
 
 #[cfg(test)]

--- a/library/riscv-aia/src/register/hvien.rs
+++ b/library/riscv-aia/src/register/hvien.rs
@@ -5,3 +5,22 @@ riscv::read_write_csr! {
     Hvien: 0x608,
     mask: 0xFFFF_FFFF_FFFF_FFFF,
 }
+
+impl Hvien {
+    #[inline]
+    pub const fn bit(self, n: usize) -> bool {
+        ((self.bits >> n) & 1) != 0
+    }
+
+    /// VS-level software interrupt enable (bit 2).
+    #[inline]
+    pub const fn vssip(self) -> bool { self.bit(2) }
+
+    /// VS-level timer interrupt enable (bit 6).
+    #[inline]
+    pub const fn vstip(self) -> bool { self.bit(6) }
+
+    /// VS-level external interrupt enable (bit 10).
+    #[inline]
+    pub const fn vseip(self) -> bool { self.bit(10) }
+}

--- a/library/riscv-aia/src/register/hvien.rs
+++ b/library/riscv-aia/src/register/hvien.rs
@@ -1,0 +1,7 @@
+//! Hypervisor virtual interrupt enables (hvien)
+
+riscv::read_write_csr! {
+    /// Hypervisor virtual interrupt enables.
+    Hvien: 0x608,
+    mask: 0xFFFF_FFFF_FFFF_FFFF,
+}

--- a/library/riscv-aia/src/register/hvien.rs
+++ b/library/riscv-aia/src/register/hvien.rs
@@ -24,3 +24,23 @@ impl Hvien {
     #[inline]
     pub const fn vseip(self) -> bool { self.bit(10) }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::register::hvip::Hvip;
+
+    #[test]
+    fn hvien_hvip_bits() {
+        // set vssip (bit 2), vstip (bit 6), vseip (bit 10)
+        let bits: usize = (1usize << 2) | (1usize << 6) | (1usize << 10);
+        let en = Hvien::from_bits(bits);
+        let pend = Hvip::from_bits(bits);
+        assert!(en.vssip());
+        assert!(en.vstip());
+        assert!(en.vseip());
+        assert!(pend.vssip());
+        assert!(pend.vstip());
+        assert!(pend.vseip());
+    }
+}

--- a/library/riscv-aia/src/register/hvienh.rs
+++ b/library/riscv-aia/src/register/hvienh.rs
@@ -1,0 +1,7 @@
+//! Hypervisor virtual interrupt enables high-half (hvienh) (RV32 only)
+
+riscv::read_write_csr! {
+    /// Upper 32 bits of hvien.
+    Hvienh: 0x618,
+    mask: 0xFFFF_FFFF,
+}

--- a/library/riscv-aia/src/register/hvienh.rs
+++ b/library/riscv-aia/src/register/hvienh.rs
@@ -5,3 +5,8 @@ riscv::read_write_csr! {
     Hvienh: 0x618,
     mask: 0xFFFF_FFFF,
 }
+
+impl Hvienh {
+    #[inline]
+    pub const fn raw(self) -> usize { self.bits }
+}

--- a/library/riscv-aia/src/register/hvienh.rs
+++ b/library/riscv-aia/src/register/hvienh.rs
@@ -10,3 +10,18 @@ impl Hvienh {
     #[inline]
     pub const fn raw(self) -> usize { self.bits }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::register::hviph::Hviph;
+
+    #[test]
+    fn hvienh_hviph_raw_roundtrip() {
+        let bits: usize = 0xDEAD_BEEFusize & 0xFFFF_FFFF;
+        let en = Hvienh::from_bits(bits);
+        let p = Hviph::from_bits(bits);
+        assert_eq!(en.raw(), bits);
+        assert_eq!(p.raw(), bits);
+    }
+}

--- a/library/riscv-aia/src/register/hvienh.rs
+++ b/library/riscv-aia/src/register/hvienh.rs
@@ -8,7 +8,9 @@ riscv::read_write_csr! {
 
 impl Hvienh {
     #[inline]
-    pub const fn raw(self) -> usize { self.bits }
+    pub const fn raw(self) -> usize {
+        self.bits
+    }
 }
 
 #[cfg(test)]

--- a/library/riscv-aia/src/register/hvip.rs
+++ b/library/riscv-aia/src/register/hvip.rs
@@ -24,3 +24,23 @@ impl Hvip {
     #[inline]
     pub const fn vseip(self) -> bool { self.bit(10) }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::register::hvien::Hvien;
+
+    #[test]
+    fn hvien_hvip_bits() {
+        // set vssip (bit 2), vstip (bit 6), vseip (bit 10)
+        let bits: usize = (1usize << 2) | (1usize << 6) | (1usize << 10);
+        let en = Hvien::from_bits(bits);
+        let pend = Hvip::from_bits(bits);
+        assert!(en.vssip());
+        assert!(en.vstip());
+        assert!(en.vseip());
+        assert!(pend.vssip());
+        assert!(pend.vstip());
+        assert!(pend.vseip());
+    }
+}

--- a/library/riscv-aia/src/register/hvip.rs
+++ b/library/riscv-aia/src/register/hvip.rs
@@ -14,15 +14,21 @@ impl Hvip {
 
     /// VS-level software interrupt pending (bit 2).
     #[inline]
-    pub const fn vssip(self) -> bool { self.bit(2) }
+    pub const fn vssip(self) -> bool {
+        self.bit(2)
+    }
 
     /// VS-level timer interrupt pending (bit 6).
     #[inline]
-    pub const fn vstip(self) -> bool { self.bit(6) }
+    pub const fn vstip(self) -> bool {
+        self.bit(6)
+    }
 
     /// VS-level external interrupt pending (bit 10).
     #[inline]
-    pub const fn vseip(self) -> bool { self.bit(10) }
+    pub const fn vseip(self) -> bool {
+        self.bit(10)
+    }
 }
 
 #[cfg(test)]

--- a/library/riscv-aia/src/register/hvip.rs
+++ b/library/riscv-aia/src/register/hvip.rs
@@ -5,3 +5,22 @@ riscv::read_write_csr! {
     Hvip: 0x645,
     mask: 0xFFFF_FFFF_FFFF_FFFF,
 }
+
+impl Hvip {
+    #[inline]
+    pub const fn bit(self, n: usize) -> bool {
+        ((self.bits >> n) & 1) != 0
+    }
+
+    /// VS-level software interrupt pending (bit 2).
+    #[inline]
+    pub const fn vssip(self) -> bool { self.bit(2) }
+
+    /// VS-level timer interrupt pending (bit 6).
+    #[inline]
+    pub const fn vstip(self) -> bool { self.bit(6) }
+
+    /// VS-level external interrupt pending (bit 10).
+    #[inline]
+    pub const fn vseip(self) -> bool { self.bit(10) }
+}

--- a/library/riscv-aia/src/register/hvip.rs
+++ b/library/riscv-aia/src/register/hvip.rs
@@ -1,0 +1,7 @@
+//! Hypervisor virtual interrupt pending bits (hvip)
+
+riscv::read_write_csr! {
+    /// Hypervisor virtual interrupt pending bits.
+    Hvip: 0x645,
+    mask: 0xFFFF_FFFF_FFFF_FFFF,
+}

--- a/library/riscv-aia/src/register/hviph.rs
+++ b/library/riscv-aia/src/register/hviph.rs
@@ -5,3 +5,8 @@ riscv::read_write_csr! {
     Hviph: 0x655,
     mask: 0xFFFF_FFFF,
 }
+
+impl Hviph {
+    #[inline]
+    pub const fn raw(self) -> usize { self.bits }
+}

--- a/library/riscv-aia/src/register/hviph.rs
+++ b/library/riscv-aia/src/register/hviph.rs
@@ -8,7 +8,9 @@ riscv::read_write_csr! {
 
 impl Hviph {
     #[inline]
-    pub const fn raw(self) -> usize { self.bits }
+    pub const fn raw(self) -> usize {
+        self.bits
+    }
 }
 
 #[cfg(test)]

--- a/library/riscv-aia/src/register/hviph.rs
+++ b/library/riscv-aia/src/register/hviph.rs
@@ -1,0 +1,7 @@
+//! Hypervisor virtual interrupt pending high-half (hviph) (RV32 only)
+
+riscv::read_write_csr! {
+    /// Upper 32 bits of hvip.
+    Hviph: 0x655,
+    mask: 0xFFFF_FFFF,
+}

--- a/library/riscv-aia/src/register/hviph.rs
+++ b/library/riscv-aia/src/register/hviph.rs
@@ -10,3 +10,18 @@ impl Hviph {
     #[inline]
     pub const fn raw(self) -> usize { self.bits }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::register::hvienh::Hvienh;
+
+    #[test]
+    fn hvienh_hviph_raw_roundtrip() {
+        let bits: usize = 0xDEAD_BEEFusize & 0xFFFF_FFFF;
+        let en = Hvienh::from_bits(bits);
+        let p = Hviph::from_bits(bits);
+        assert_eq!(en.raw(), bits);
+        assert_eq!(p.raw(), bits);
+    }
+}

--- a/library/riscv-aia/src/register/hviprio1.rs
+++ b/library/riscv-aia/src/register/hviprio1.rs
@@ -15,3 +15,24 @@ impl Hviprio1 {
         ((self.bits >> shift) & 0xFF) as u8
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::register::hviprio2::Hviprio2;
+
+    #[test]
+    fn hviprio_prio_bytes() {
+        // build a 64-bit value with known bytes: 0x00..07
+        let mut val: usize = 0;
+        for i in 0..8 {
+            val |= (i as usize & 0xFF) << (i * 8);
+        }
+        let r1 = Hviprio1::from_bits(val);
+        let r2 = Hviprio2::from_bits(val);
+        for i in 0..8 {
+            assert_eq!(r1.prio_byte(i), i as u8);
+            assert_eq!(r2.prio_byte(i), i as u8);
+        }
+    }
+}

--- a/library/riscv-aia/src/register/hviprio1.rs
+++ b/library/riscv-aia/src/register/hviprio1.rs
@@ -1,0 +1,7 @@
+//! Hypervisor VS-level interrupt priority 1 (hviprio1)
+
+riscv::read_write_csr! {
+    /// Hypervisor VS-level interrupt priority 1.
+    Hviprio1: 0x646,
+    mask: 0xFFFF_FFFF_FFFF_FFFF,
+}

--- a/library/riscv-aia/src/register/hviprio1.rs
+++ b/library/riscv-aia/src/register/hviprio1.rs
@@ -5,3 +5,13 @@ riscv::read_write_csr! {
     Hviprio1: 0x646,
     mask: 0xFFFF_FFFF_FFFF_FFFF,
 }
+
+impl Hviprio1 {
+    /// Returns the priority byte at byte index `i` (0..7).
+    /// Byte 0 corresponds to bits 7:0, byte 1 to bits 15:8, etc.
+    #[inline]
+    pub const fn prio_byte(self, i: usize) -> u8 {
+        let shift = (i as usize) * 8;
+        ((self.bits >> shift) & 0xFF) as u8
+    }
+}

--- a/library/riscv-aia/src/register/hviprio1h.rs
+++ b/library/riscv-aia/src/register/hviprio1h.rs
@@ -10,3 +10,15 @@ impl Hviprio1h {
     #[inline]
     pub const fn raw(self) -> usize { self.bits }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn hviprio1h_raw_roundtrip() {
+        let bits: usize = 0xDEAD_BEEFusize & 0xFFFF_FFFF;
+        let reg = Hviprio1h::from_bits(bits);
+        assert_eq!(reg.raw(), bits);
+    }
+}

--- a/library/riscv-aia/src/register/hviprio1h.rs
+++ b/library/riscv-aia/src/register/hviprio1h.rs
@@ -5,3 +5,8 @@ riscv::read_write_csr! {
     Hviprio1h: 0x656,
     mask: 0xFFFF_FFFF,
 }
+
+impl Hviprio1h {
+    #[inline]
+    pub const fn raw(self) -> usize { self.bits }
+}

--- a/library/riscv-aia/src/register/hviprio1h.rs
+++ b/library/riscv-aia/src/register/hviprio1h.rs
@@ -1,0 +1,7 @@
+//! Hypervisor VIPRIO1 high-half (hviprio1h) (RV32 only)
+
+riscv::read_write_csr! {
+    /// Upper 32 bits of hviprio1.
+    Hviprio1h: 0x656,
+    mask: 0xFFFF_FFFF,
+}

--- a/library/riscv-aia/src/register/hviprio1h.rs
+++ b/library/riscv-aia/src/register/hviprio1h.rs
@@ -8,7 +8,9 @@ riscv::read_write_csr! {
 
 impl Hviprio1h {
     #[inline]
-    pub const fn raw(self) -> usize { self.bits }
+    pub const fn raw(self) -> usize {
+        self.bits
+    }
 }
 
 #[cfg(test)]

--- a/library/riscv-aia/src/register/hviprio2.rs
+++ b/library/riscv-aia/src/register/hviprio2.rs
@@ -1,0 +1,7 @@
+//! Hypervisor VS-level interrupt priority 2 (hviprio2)
+
+riscv::read_write_csr! {
+    /// Hypervisor VS-level interrupt priority 2.
+    Hviprio2: 0x647,
+    mask: 0xFFFF_FFFF_FFFF_FFFF,
+}

--- a/library/riscv-aia/src/register/hviprio2.rs
+++ b/library/riscv-aia/src/register/hviprio2.rs
@@ -5,3 +5,12 @@ riscv::read_write_csr! {
     Hviprio2: 0x647,
     mask: 0xFFFF_FFFF_FFFF_FFFF,
 }
+
+impl Hviprio2 {
+    /// Returns the priority byte at byte index `i` (0..7).
+    #[inline]
+    pub const fn prio_byte(self, i: usize) -> u8 {
+        let shift = (i as usize) * 8;
+        ((self.bits >> shift) & 0xFF) as u8
+    }
+}

--- a/library/riscv-aia/src/register/hviprio2.rs
+++ b/library/riscv-aia/src/register/hviprio2.rs
@@ -14,3 +14,24 @@ impl Hviprio2 {
         ((self.bits >> shift) & 0xFF) as u8
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::register::hviprio1::Hviprio1;
+
+    #[test]
+    fn hviprio_prio_bytes() {
+        // build a 64-bit value with known bytes: 0x00..07
+        let mut val: usize = 0;
+        for i in 0..8 {
+            val |= (i as usize & 0xFF) << (i * 8);
+        }
+        let r1 = Hviprio1::from_bits(val);
+        let r2 = Hviprio2::from_bits(val);
+        for i in 0..8 {
+            assert_eq!(r1.prio_byte(i), i as u8);
+            assert_eq!(r2.prio_byte(i), i as u8);
+        }
+    }
+}

--- a/library/riscv-aia/src/register/hviprio2h.rs
+++ b/library/riscv-aia/src/register/hviprio2h.rs
@@ -10,3 +10,15 @@ impl Hviprio2h {
     #[inline]
     pub const fn raw(self) -> usize { self.bits }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn hviprio2h_raw_roundtrip() {
+        let bits: usize = 0x1234_5678usize & 0xFFFF_FFFF;
+        let reg = Hviprio2h::from_bits(bits);
+        assert_eq!(reg.raw(), bits);
+    }
+}

--- a/library/riscv-aia/src/register/hviprio2h.rs
+++ b/library/riscv-aia/src/register/hviprio2h.rs
@@ -8,7 +8,9 @@ riscv::read_write_csr! {
 
 impl Hviprio2h {
     #[inline]
-    pub const fn raw(self) -> usize { self.bits }
+    pub const fn raw(self) -> usize {
+        self.bits
+    }
 }
 
 #[cfg(test)]

--- a/library/riscv-aia/src/register/hviprio2h.rs
+++ b/library/riscv-aia/src/register/hviprio2h.rs
@@ -5,3 +5,8 @@ riscv::read_write_csr! {
     Hviprio2h: 0x657,
     mask: 0xFFFF_FFFF,
 }
+
+impl Hviprio2h {
+    #[inline]
+    pub const fn raw(self) -> usize { self.bits }
+}

--- a/library/riscv-aia/src/register/hviprio2h.rs
+++ b/library/riscv-aia/src/register/hviprio2h.rs
@@ -1,0 +1,7 @@
+//! Hypervisor VIPRIO2 high-half (hviprio2h) (RV32 only)
+
+riscv::read_write_csr! {
+    /// Upper 32 bits of hviprio2.
+    Hviprio2h: 0x657,
+    mask: 0xFFFF_FFFF,
+}

--- a/library/riscv-aia/src/register/mideleg.rs
+++ b/library/riscv-aia/src/register/mideleg.rs
@@ -5,3 +5,23 @@ riscv::read_write_csr! {
     Mideleg: 0x303,
     mask: 0xFFFF_FFFF_FFFF_FFFF,
 }
+
+impl Mideleg {
+    /// Test bit `n` of `mideleg` (generic helper).
+    #[inline]
+    pub const fn bit(self, n: usize) -> bool {
+        ((self.bits >> n) & 1) != 0
+    }
+
+    /// Supervisor software interrupt delegation (bit 1).
+    #[inline]
+    pub const fn ssip(self) -> bool { self.bit(1) }
+
+    /// Supervisor timer interrupt delegation (bit 5).
+    #[inline]
+    pub const fn stip(self) -> bool { self.bit(5) }
+
+    /// Supervisor external interrupt delegation (bit 9).
+    #[inline]
+    pub const fn seip(self) -> bool { self.bit(9) }
+}

--- a/library/riscv-aia/src/register/mideleg.rs
+++ b/library/riscv-aia/src/register/mideleg.rs
@@ -1,0 +1,7 @@
+//! Machine interrupt delegation (mideleg)
+
+riscv::read_write_csr! {
+    /// Machine interrupt delegation.
+    Mideleg: 0x303,
+    mask: 0xFFFF_FFFF_FFFF_FFFF,
+}

--- a/library/riscv-aia/src/register/mideleg.rs
+++ b/library/riscv-aia/src/register/mideleg.rs
@@ -25,3 +25,22 @@ impl Mideleg {
     #[inline]
     pub const fn seip(self) -> bool { self.bit(9) }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::register::hideleg::Hideleg;
+
+    #[test]
+    fn mideleg_hideleg_bits() {
+        let bits: usize = (1usize << 1) | (1usize << 5) | (1usize << 9);
+        let md = Mideleg::from_bits(bits);
+        let hd = Hideleg::from_bits(bits);
+        assert!(md.ssip());
+        assert!(md.stip());
+        assert!(md.seip());
+        assert!(hd.ssip());
+        assert!(hd.stip());
+        assert!(hd.seip());
+    }
+}

--- a/library/riscv-aia/src/register/mideleg.rs
+++ b/library/riscv-aia/src/register/mideleg.rs
@@ -15,15 +15,21 @@ impl Mideleg {
 
     /// Supervisor software interrupt delegation (bit 1).
     #[inline]
-    pub const fn ssip(self) -> bool { self.bit(1) }
+    pub const fn ssip(self) -> bool {
+        self.bit(1)
+    }
 
     /// Supervisor timer interrupt delegation (bit 5).
     #[inline]
-    pub const fn stip(self) -> bool { self.bit(5) }
+    pub const fn stip(self) -> bool {
+        self.bit(5)
+    }
 
     /// Supervisor external interrupt delegation (bit 9).
     #[inline]
-    pub const fn seip(self) -> bool { self.bit(9) }
+    pub const fn seip(self) -> bool {
+        self.bit(9)
+    }
 }
 
 #[cfg(test)]

--- a/library/riscv-aia/src/register/midelegh.rs
+++ b/library/riscv-aia/src/register/midelegh.rs
@@ -18,4 +18,21 @@ riscv::read_write_csr_field! {
     high_priority_ras_event: 11, // 43 - 32
 }
 
-// TODO mod tests
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn midelegh_fields_bits() {
+        // low_priority_ras_event is at bit 3, high_priority_ras_event at bit 11
+        let bits: usize = (1usize << 3) | (1usize << 11);
+        let reg = Midelegh::from_bits(bits);
+        // The macro-generated accessors are expected to be named after the fields.
+        assert!(reg.low_priority_ras_event());
+        assert!(reg.high_priority_ras_event());
+        // unset a bit
+        let reg2 = Midelegh::from_bits(0);
+        assert!(!reg2.low_priority_ras_event());
+        assert!(!reg2.high_priority_ras_event());
+    }
+}

--- a/library/riscv-aia/src/register/mie.rs
+++ b/library/riscv-aia/src/register/mie.rs
@@ -14,27 +14,39 @@ impl Mie {
 
     /// Supervisor software interrupt enable (bit 1).
     #[inline]
-    pub const fn ssip(self) -> bool { self.bit(1) }
+    pub const fn ssip(self) -> bool {
+        self.bit(1)
+    }
 
     /// Supervisor timer interrupt enable (bit 5).
     #[inline]
-    pub const fn stip(self) -> bool { self.bit(5) }
+    pub const fn stip(self) -> bool {
+        self.bit(5)
+    }
 
     /// Supervisor external interrupt enable (bit 9).
     #[inline]
-    pub const fn seip(self) -> bool { self.bit(9) }
+    pub const fn seip(self) -> bool {
+        self.bit(9)
+    }
 
     /// Machine software interrupt enable (bit 3).
     #[inline]
-    pub const fn msip(self) -> bool { self.bit(3) }
+    pub const fn msip(self) -> bool {
+        self.bit(3)
+    }
 
     /// Machine timer interrupt enable (bit 7).
     #[inline]
-    pub const fn mtip(self) -> bool { self.bit(7) }
+    pub const fn mtip(self) -> bool {
+        self.bit(7)
+    }
 
     /// Machine external interrupt enable (bit 11).
     #[inline]
-    pub const fn meip(self) -> bool { self.bit(11) }
+    pub const fn meip(self) -> bool {
+        self.bit(11)
+    }
 }
 
 #[cfg(test)]

--- a/library/riscv-aia/src/register/mie.rs
+++ b/library/riscv-aia/src/register/mie.rs
@@ -5,3 +5,34 @@ riscv::read_write_csr! {
     Mie: 0x304,
     mask: 0xFFFF_FFFF_FFFF_FFFF,
 }
+
+impl Mie {
+    #[inline]
+    pub const fn bit(self, n: usize) -> bool {
+        ((self.bits >> n) & 1) != 0
+    }
+
+    /// Supervisor software interrupt enable (bit 1).
+    #[inline]
+    pub const fn ssip(self) -> bool { self.bit(1) }
+
+    /// Supervisor timer interrupt enable (bit 5).
+    #[inline]
+    pub const fn stip(self) -> bool { self.bit(5) }
+
+    /// Supervisor external interrupt enable (bit 9).
+    #[inline]
+    pub const fn seip(self) -> bool { self.bit(9) }
+
+    /// Machine software interrupt enable (bit 3).
+    #[inline]
+    pub const fn msip(self) -> bool { self.bit(3) }
+
+    /// Machine timer interrupt enable (bit 7).
+    #[inline]
+    pub const fn mtip(self) -> bool { self.bit(7) }
+
+    /// Machine external interrupt enable (bit 11).
+    #[inline]
+    pub const fn meip(self) -> bool { self.bit(11) }
+}

--- a/library/riscv-aia/src/register/mie.rs
+++ b/library/riscv-aia/src/register/mie.rs
@@ -1,0 +1,7 @@
+//! Machine interrupt-enable bits (mie)
+
+riscv::read_write_csr! {
+    /// Machine interrupt-enable bits.
+    Mie: 0x304,
+    mask: 0xFFFF_FFFF_FFFF_FFFF,
+}

--- a/library/riscv-aia/src/register/mie.rs
+++ b/library/riscv-aia/src/register/mie.rs
@@ -36,3 +36,35 @@ impl Mie {
     #[inline]
     pub const fn meip(self) -> bool { self.bit(11) }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::register::mip::Mip;
+
+    #[test]
+    fn mie_mip_delegate_bits() {
+        // ensure mie/mip still behave as expected alongside delegation
+        let bits: usize = (1usize << 3) | (1usize << 7) | (1usize << 11);
+        let en = Mie::from_bits(bits);
+        let pd = Mip::from_bits(bits);
+        assert!(en.msip());
+        assert!(en.mtip());
+        assert!(en.meip());
+        assert!(pd.msip());
+        assert!(pd.mtip());
+        assert!(pd.meip());
+    }
+
+    #[test]
+    fn mie_parsing_bits() {
+        // set msip (bit 3), mtip (bit 7), meip (bit 11)
+        let bits: usize = (1usize << 3) | (1usize << 7) | (1usize << 11);
+        let reg = Mie::from_bits(bits);
+        assert!(reg.msip());
+        assert!(reg.mtip());
+        assert!(reg.meip());
+        // other bits like ssip should be false
+        assert!(!reg.ssip());
+    }
+}

--- a/library/riscv-aia/src/register/mieh.rs
+++ b/library/riscv-aia/src/register/mieh.rs
@@ -1,0 +1,7 @@
+//! Machine interrupt-enable high-half (RV32 only) (mieh)
+
+riscv::read_write_csr! {
+    /// Upper 32 bits of mie (RV32 only).
+    Mieh: 0x314,
+    mask: 0xFFFF_FFFF,
+}

--- a/library/riscv-aia/src/register/mieh.rs
+++ b/library/riscv-aia/src/register/mieh.rs
@@ -10,3 +10,15 @@ impl Mieh {
     #[inline]
     pub const fn raw(self) -> usize { self.bits }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn mieh_raw_roundtrip() {
+        let bits: usize = 0xDEADBEEFusize & 0xFFFF_FFFF;
+        let reg = Mieh::from_bits(bits);
+        assert_eq!(reg.raw(), bits);
+    }
+}

--- a/library/riscv-aia/src/register/mieh.rs
+++ b/library/riscv-aia/src/register/mieh.rs
@@ -8,7 +8,9 @@ riscv::read_write_csr! {
 
 impl Mieh {
     #[inline]
-    pub const fn raw(self) -> usize { self.bits }
+    pub const fn raw(self) -> usize {
+        self.bits
+    }
 }
 
 #[cfg(test)]

--- a/library/riscv-aia/src/register/mieh.rs
+++ b/library/riscv-aia/src/register/mieh.rs
@@ -5,3 +5,8 @@ riscv::read_write_csr! {
     Mieh: 0x314,
     mask: 0xFFFF_FFFF,
 }
+
+impl Mieh {
+    #[inline]
+    pub const fn raw(self) -> usize { self.bits }
+}

--- a/library/riscv-aia/src/register/mip.rs
+++ b/library/riscv-aia/src/register/mip.rs
@@ -36,3 +36,34 @@ impl Mip {
     #[inline]
     pub const fn meip(self) -> bool { self.bit(11) }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::register::mie::Mie;
+
+    #[test]
+    fn mie_mip_delegate_bits() {
+        // ensure mie/mip still behave as expected alongside delegation
+        let bits: usize = (1usize << 3) | (1usize << 7) | (1usize << 11);
+        let en = Mie::from_bits(bits);
+        let pd = Mip::from_bits(bits);
+        assert!(en.msip());
+        assert!(en.mtip());
+        assert!(en.meip());
+        assert!(pd.msip());
+        assert!(pd.mtip());
+        assert!(pd.meip());
+    }
+
+    #[test]
+    fn mip_parsing_bits() {
+        // set msip (bit 3), mtip (bit 7), meip (bit 11)
+        let bits: usize = (1usize << 3) | (1usize << 7) | (1usize << 11);
+        let reg = Mip::from_bits(bits);
+        assert!(reg.msip());
+        assert!(reg.mtip());
+        assert!(reg.meip());
+        assert!(!reg.ssip());
+    }
+}

--- a/library/riscv-aia/src/register/mip.rs
+++ b/library/riscv-aia/src/register/mip.rs
@@ -14,27 +14,39 @@ impl Mip {
 
     /// Supervisor software interrupt pending (bit 1).
     #[inline]
-    pub const fn ssip(self) -> bool { self.bit(1) }
+    pub const fn ssip(self) -> bool {
+        self.bit(1)
+    }
 
     /// Supervisor timer interrupt pending (bit 5).
     #[inline]
-    pub const fn stip(self) -> bool { self.bit(5) }
+    pub const fn stip(self) -> bool {
+        self.bit(5)
+    }
 
     /// Supervisor external interrupt pending (bit 9).
     #[inline]
-    pub const fn seip(self) -> bool { self.bit(9) }
+    pub const fn seip(self) -> bool {
+        self.bit(9)
+    }
 
     /// Machine software interrupt pending (bit 3).
     #[inline]
-    pub const fn msip(self) -> bool { self.bit(3) }
+    pub const fn msip(self) -> bool {
+        self.bit(3)
+    }
 
     /// Machine timer interrupt pending (bit 7).
     #[inline]
-    pub const fn mtip(self) -> bool { self.bit(7) }
+    pub const fn mtip(self) -> bool {
+        self.bit(7)
+    }
 
     /// Machine external interrupt pending (bit 11).
     #[inline]
-    pub const fn meip(self) -> bool { self.bit(11) }
+    pub const fn meip(self) -> bool {
+        self.bit(11)
+    }
 }
 
 #[cfg(test)]

--- a/library/riscv-aia/src/register/mip.rs
+++ b/library/riscv-aia/src/register/mip.rs
@@ -1,0 +1,7 @@
+//! Machine interrupt-pending bits (mip)
+
+riscv::read_write_csr! {
+    /// Machine interrupt-pending bits.
+    Mip: 0x344,
+    mask: 0xFFFF_FFFF_FFFF_FFFF,
+}

--- a/library/riscv-aia/src/register/mip.rs
+++ b/library/riscv-aia/src/register/mip.rs
@@ -5,3 +5,34 @@ riscv::read_write_csr! {
     Mip: 0x344,
     mask: 0xFFFF_FFFF_FFFF_FFFF,
 }
+
+impl Mip {
+    #[inline]
+    pub const fn bit(self, n: usize) -> bool {
+        ((self.bits >> n) & 1) != 0
+    }
+
+    /// Supervisor software interrupt pending (bit 1).
+    #[inline]
+    pub const fn ssip(self) -> bool { self.bit(1) }
+
+    /// Supervisor timer interrupt pending (bit 5).
+    #[inline]
+    pub const fn stip(self) -> bool { self.bit(5) }
+
+    /// Supervisor external interrupt pending (bit 9).
+    #[inline]
+    pub const fn seip(self) -> bool { self.bit(9) }
+
+    /// Machine software interrupt pending (bit 3).
+    #[inline]
+    pub const fn msip(self) -> bool { self.bit(3) }
+
+    /// Machine timer interrupt pending (bit 7).
+    #[inline]
+    pub const fn mtip(self) -> bool { self.bit(7) }
+
+    /// Machine external interrupt pending (bit 11).
+    #[inline]
+    pub const fn meip(self) -> bool { self.bit(11) }
+}

--- a/library/riscv-aia/src/register/miph.rs
+++ b/library/riscv-aia/src/register/miph.rs
@@ -1,0 +1,7 @@
+//! Machine interrupt-pending high-half (miph) (RV32 only)
+
+riscv::read_write_csr! {
+    /// Upper 32 bits of mip (RV32 only).
+    Miph: 0x354,
+    mask: 0xFFFF_FFFF,
+}

--- a/library/riscv-aia/src/register/miph.rs
+++ b/library/riscv-aia/src/register/miph.rs
@@ -8,7 +8,9 @@ riscv::read_write_csr! {
 
 impl Miph {
     #[inline]
-    pub const fn raw(self) -> usize { self.bits }
+    pub const fn raw(self) -> usize {
+        self.bits
+    }
 }
 
 #[cfg(test)]

--- a/library/riscv-aia/src/register/miph.rs
+++ b/library/riscv-aia/src/register/miph.rs
@@ -5,3 +5,8 @@ riscv::read_write_csr! {
     Miph: 0x354,
     mask: 0xFFFF_FFFF,
 }
+
+impl Miph {
+    #[inline]
+    pub const fn raw(self) -> usize { self.bits }
+}

--- a/library/riscv-aia/src/register/miph.rs
+++ b/library/riscv-aia/src/register/miph.rs
@@ -10,3 +10,15 @@ impl Miph {
     #[inline]
     pub const fn raw(self) -> usize { self.bits }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn miph_raw_roundtrip() {
+        let bits: usize = 0x1234_5678usize & 0xFFFF_FFFF;
+        let reg = Miph::from_bits(bits);
+        assert_eq!(reg.raw(), bits);
+    }
+}

--- a/library/riscv-aia/src/register/mireg.rs
+++ b/library/riscv-aia/src/register/mireg.rs
@@ -5,3 +5,13 @@ riscv::read_write_csr! {
     Mireg: 0x351,
     mask: 0xFFFF_FFFF_FFFF_FFFF,
 }
+
+impl Mireg {
+    /// Raw bits read from `mireg` (convenience accessors - width depends on XLEN).
+    #[inline]
+    pub const fn raw(self) -> usize { self.bits }
+
+    /// Raw bits as usize convenience accessor.
+    #[inline]
+    pub const fn as_usize(self) -> usize { self.bits }
+}

--- a/library/riscv-aia/src/register/mireg.rs
+++ b/library/riscv-aia/src/register/mireg.rs
@@ -15,3 +15,21 @@ impl Mireg {
     #[inline]
     pub const fn as_usize(self) -> usize { self.bits }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::register::miselect::Miselect;
+
+    #[test]
+    fn miselect_value_and_mireg_raw() {
+        let sel: usize = 0x42;
+        let s = Miselect::from_bits(sel);
+        assert_eq!(s.value(), sel);
+
+        let rbits: usize = 0x1234_5678usize & 0xFFFF_FFFF_FFFF_FFFF;
+        let r = Mireg::from_bits(rbits);
+        assert_eq!(r.raw(), rbits);
+        assert_eq!(r.as_usize(), rbits);
+    }
+}

--- a/library/riscv-aia/src/register/mireg.rs
+++ b/library/riscv-aia/src/register/mireg.rs
@@ -1,0 +1,7 @@
+//! Machine indirect register alias (mireg)
+
+riscv::read_write_csr! {
+    /// Machine indirect register alias.
+    Mireg: 0x351,
+    mask: 0xFFFF_FFFF_FFFF_FFFF,
+}

--- a/library/riscv-aia/src/register/mireg.rs
+++ b/library/riscv-aia/src/register/mireg.rs
@@ -9,11 +9,15 @@ riscv::read_write_csr! {
 impl Mireg {
     /// Raw bits read from `mireg` (convenience accessors - width depends on XLEN).
     #[inline]
-    pub const fn raw(self) -> usize { self.bits }
+    pub const fn raw(self) -> usize {
+        self.bits
+    }
 
     /// Raw bits as usize convenience accessor.
     #[inline]
-    pub const fn as_usize(self) -> usize { self.bits }
+    pub const fn as_usize(self) -> usize {
+        self.bits
+    }
 }
 
 #[cfg(test)]

--- a/library/riscv-aia/src/register/miselect.rs
+++ b/library/riscv-aia/src/register/miselect.rs
@@ -7,3 +7,13 @@ riscv::read_write_csr! {
 }
 
 // Note: miselect controls which register is accessed via `mireg`.
+
+impl Miselect {
+    /// Current value of `miselect` as usize (convenience accessor).
+    #[inline]
+    pub const fn value(self) -> usize {
+        self.bits as usize
+    }
+
+    // Note: writing to `miselect` should be done via the generated CSR API.
+}

--- a/library/riscv-aia/src/register/miselect.rs
+++ b/library/riscv-aia/src/register/miselect.rs
@@ -1,0 +1,9 @@
+//! Machine indirect register select (miselect)
+
+riscv::read_write_csr! {
+    /// Machine indirect register select.
+    Miselect: 0x350,
+    mask: 0xFFFF_FFFF_FFFF_FFFF,
+}
+
+// Note: miselect controls which register is accessed via `mireg`.

--- a/library/riscv-aia/src/register/miselect.rs
+++ b/library/riscv-aia/src/register/miselect.rs
@@ -17,3 +17,21 @@ impl Miselect {
 
     // Note: writing to `miselect` should be done via the generated CSR API.
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::register::mireg::Mireg;
+
+    #[test]
+    fn miselect_value_and_mireg_raw() {
+        let sel: usize = 0x42;
+        let s = Miselect::from_bits(sel);
+        assert_eq!(s.value(), sel);
+
+        let rbits: usize = 0x1234_5678usize & 0xFFFF_FFFF_FFFF_FFFF;
+        let r = Mireg::from_bits(rbits);
+        assert_eq!(r.raw(), rbits);
+        assert_eq!(r.as_usize(), rbits);
+    }
+}

--- a/library/riscv-aia/src/register/mtopei.rs
+++ b/library/riscv-aia/src/register/mtopei.rs
@@ -1,5 +1,29 @@
 //! Machine-level top external interrupt register (only with an IMSIC).
+//! Machine-level top external interrupt register (only with an IMSIC).
+//!
+//! CSR `mtopei` reports the highest-priority external interrupt that is
+//! pending and enabled for machine-level when an IMSIC is present. Provide a
+//! small typed wrapper similar to `Mtopi` for convenient field extraction.
 
-// TODO structure level representations
+use crate::Iid;
 
-riscv::read_csr_as_usize!(0x35C);
+riscv::read_only_csr! {
+	/// Machine top external interrupt (mtopei).
+	Mtopei: 0x35C,
+	mask: 0x0FFF_00FF,
+}
+
+impl Mtopei {
+	/// Get the major identity number of the highest-priority external interrupt.
+	#[inline]
+	pub const fn iid(self) -> Option<Iid> {
+		let bits = (self.bits & 0x0FFF_0000) >> 16;
+		Iid::new(bits as u16)
+	}
+
+	/// Indicates the priority number of the highest-priority external interrupt.
+	#[inline]
+	pub const fn iprio(self) -> u8 {
+		(self.bits & 0x0000_00FF) as u8
+	}
+}

--- a/library/riscv-aia/src/register/mtopei.rs
+++ b/library/riscv-aia/src/register/mtopei.rs
@@ -8,24 +8,24 @@
 use crate::Iid;
 
 riscv::read_only_csr! {
-	/// Machine top external interrupt (mtopei).
-	Mtopei: 0x35C,
-	mask: 0x0FFF_00FF,
+    /// Machine top external interrupt (mtopei).
+    Mtopei: 0x35C,
+    mask: 0x0FFF_00FF,
 }
 
 impl Mtopei {
-	/// Get the major identity number of the highest-priority external interrupt.
-	#[inline]
-	pub const fn iid(self) -> Option<Iid> {
-		let bits = (self.bits & 0x0FFF_0000) >> 16;
-		Iid::new(bits as u16)
-	}
+    /// Get the major identity number of the highest-priority external interrupt.
+    #[inline]
+    pub const fn iid(self) -> Option<Iid> {
+        let bits = (self.bits & 0x0FFF_0000) >> 16;
+        Iid::new(bits as u16)
+    }
 
-	/// Indicates the priority number of the highest-priority external interrupt.
-	#[inline]
-	pub const fn iprio(self) -> u8 {
-		(self.bits & 0x0000_00FF) as u8
-	}
+    /// Indicates the priority number of the highest-priority external interrupt.
+    #[inline]
+    pub const fn iprio(self) -> u8 {
+        (self.bits & 0x0000_00FF) as u8
+    }
 }
 
 #[cfg(test)]

--- a/library/riscv-aia/src/register/mtopei.rs
+++ b/library/riscv-aia/src/register/mtopei.rs
@@ -27,3 +27,18 @@ impl Mtopei {
 		(self.bits & 0x0000_00FF) as u8
 	}
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn mtopei_parsing() {
+        let iid_num: u16 = 1;
+        let iprio: u8 = 0xAA;
+        let bits: usize = ((iid_num as usize) << 16) | (iprio as usize);
+        let reg = Mtopei::from_bits(bits);
+        assert_eq!(reg.iprio(), iprio);
+        assert_eq!(reg.iid().map(|i| i.number()), Some(iid_num));
+    }
+}

--- a/library/riscv-aia/src/register/mtopi.rs
+++ b/library/riscv-aia/src/register/mtopi.rs
@@ -24,4 +24,32 @@ impl Mtopi {
     }
 }
 
-// TODO test module of Mtopi and Iid structures.
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn mtopi_parsing() {
+        // iid = 0x123, iprio = 0x7
+        let iid_num: u16 = 0x123;
+        let iprio: u8 = 0x7;
+        let bits: usize = ((iid_num as usize) << 16) | (iprio as usize);
+        let reg = Mtopi::from_bits(bits);
+        assert_eq!(reg.iprio(), iprio);
+        assert_eq!(reg.iid().map(|i| i.number()), Some(iid_num));
+    }
+
+    #[test]
+    fn mtopi_edge_cases() {
+        // iid = 0 -> none
+        let reg = Mtopi::from_bits(0);
+        assert!(reg.iid().is_none());
+        assert_eq!(reg.iprio(), 0);
+
+        // iid = 1, iprio = 0xFF
+        let bits: usize = (1usize << 16) | 0xFF;
+        let reg2 = Mtopi::from_bits(bits);
+        assert_eq!(reg2.iid().map(|i| i.number()), Some(1));
+        assert_eq!(reg2.iprio(), 0xFF);
+    }
+}

--- a/library/riscv-aia/src/register/mvieh.rs
+++ b/library/riscv-aia/src/register/mvieh.rs
@@ -5,3 +5,8 @@ riscv::read_write_csr! {
     Mvieh: 0x318,
     mask: 0xFFFF_FFFF,
 }
+
+impl Mvieh {
+    #[inline]
+    pub const fn raw(self) -> usize { self.bits }
+}

--- a/library/riscv-aia/src/register/mvieh.rs
+++ b/library/riscv-aia/src/register/mvieh.rs
@@ -8,7 +8,9 @@ riscv::read_write_csr! {
 
 impl Mvieh {
     #[inline]
-    pub const fn raw(self) -> usize { self.bits }
+    pub const fn raw(self) -> usize {
+        self.bits
+    }
 }
 
 #[cfg(test)]

--- a/library/riscv-aia/src/register/mvieh.rs
+++ b/library/riscv-aia/src/register/mvieh.rs
@@ -10,3 +10,15 @@ impl Mvieh {
     #[inline]
     pub const fn raw(self) -> usize { self.bits }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn mvieh_raw_roundtrip() {
+        let bits: usize = 0xCAFEBABEu32 as usize;
+        let reg = Mvieh::from_bits(bits);
+        assert_eq!(reg.raw(), bits);
+    }
+}

--- a/library/riscv-aia/src/register/mvieh.rs
+++ b/library/riscv-aia/src/register/mvieh.rs
@@ -1,0 +1,7 @@
+//! Machine virtual interrupt enables high-half (mvieh) (RV32 only)
+
+riscv::read_write_csr! {
+    /// Upper 32 bits of mvien (RV32 only).
+    Mvieh: 0x318,
+    mask: 0xFFFF_FFFF,
+}

--- a/library/riscv-aia/src/register/mvien.rs
+++ b/library/riscv-aia/src/register/mvien.rs
@@ -1,0 +1,7 @@
+//! Machine virtual interrupt enables (mvien)
+
+riscv::read_write_csr! {
+    /// Machine virtual interrupt enables.
+    Mvien: 0x308,
+    mask: 0xFFFF_FFFF_FFFF_FFFF,
+}

--- a/library/riscv-aia/src/register/mvien.rs
+++ b/library/riscv-aia/src/register/mvien.rs
@@ -5,3 +5,23 @@ riscv::read_write_csr! {
     Mvien: 0x308,
     mask: 0xFFFF_FFFF_FFFF_FFFF,
 }
+
+impl Mvien {
+    /// Supervisor software interrupt enable in mvien (bit 1).
+    #[inline]
+    pub const fn ssip(self) -> bool {
+        ((self.bits >> 1) & 1) != 0
+    }
+
+    /// Supervisor timer interrupt enable in mvien (bit 5).
+    #[inline]
+    pub const fn stip(self) -> bool {
+        ((self.bits >> 5) & 1) != 0
+    }
+
+    /// Supervisor external interrupt enable in mvien (bit 9).
+    #[inline]
+    pub const fn seip(self) -> bool {
+        ((self.bits >> 9) & 1) != 0
+    }
+}

--- a/library/riscv-aia/src/register/mvien.rs
+++ b/library/riscv-aia/src/register/mvien.rs
@@ -25,3 +25,25 @@ impl Mvien {
         ((self.bits >> 9) & 1) != 0
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn mvien_bits() {
+        let bits: usize = (1usize << 1) | (1usize << 5) | (1usize << 9);
+        let reg = Mvien::from_bits(bits);
+        assert!(reg.ssip());
+        assert!(reg.stip());
+        assert!(reg.seip());
+    }
+
+    #[test]
+    fn mvien_zero() {
+        let reg = Mvien::from_bits(0);
+        assert!(!reg.ssip());
+        assert!(!reg.stip());
+        assert!(!reg.seip());
+    }
+}

--- a/library/riscv-aia/src/register/mvip.rs
+++ b/library/riscv-aia/src/register/mvip.rs
@@ -5,3 +5,23 @@ riscv::read_write_csr! {
     Mvip: 0x309,
     mask: 0xFFFF_FFFF_FFFF_FFFF,
 }
+
+impl Mvip {
+    /// Supervisor software interrupt pending in mvip (bit 1).
+    #[inline]
+    pub const fn ssip(self) -> bool {
+        ((self.bits >> 1) & 1) != 0
+    }
+
+    /// Supervisor timer interrupt pending in mvip (bit 5).
+    #[inline]
+    pub const fn stip(self) -> bool {
+        ((self.bits >> 5) & 1) != 0
+    }
+
+    /// Supervisor external interrupt pending in mvip (bit 9).
+    #[inline]
+    pub const fn seip(self) -> bool {
+        ((self.bits >> 9) & 1) != 0
+    }
+}

--- a/library/riscv-aia/src/register/mvip.rs
+++ b/library/riscv-aia/src/register/mvip.rs
@@ -1,0 +1,7 @@
+//! Machine virtual interrupt pending bits (mvip)
+
+riscv::read_write_csr! {
+    /// Machine virtual interrupt pending bits.
+    Mvip: 0x309,
+    mask: 0xFFFF_FFFF_FFFF_FFFF,
+}

--- a/library/riscv-aia/src/register/mvip.rs
+++ b/library/riscv-aia/src/register/mvip.rs
@@ -25,3 +25,25 @@ impl Mvip {
         ((self.bits >> 9) & 1) != 0
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn mvip_bits() {
+        let bits: usize = (1usize << 1) | (1usize << 5) | (1usize << 9);
+        let reg = Mvip::from_bits(bits);
+        assert!(reg.ssip());
+        assert!(reg.stip());
+        assert!(reg.seip());
+    }
+
+    #[test]
+    fn mvip_zero() {
+        let reg = Mvip::from_bits(0);
+        assert!(!reg.ssip());
+        assert!(!reg.stip());
+        assert!(!reg.seip());
+    }
+}

--- a/library/riscv-aia/src/register/mviph.rs
+++ b/library/riscv-aia/src/register/mviph.rs
@@ -1,0 +1,7 @@
+//! Machine virtual interrupt pending high-half (mviph) (RV32 only)
+
+riscv::read_write_csr! {
+    /// Upper 32 bits of mvip (RV32 only).
+    Mviph: 0x319,
+    mask: 0xFFFF_FFFF,
+}

--- a/library/riscv-aia/src/register/mviph.rs
+++ b/library/riscv-aia/src/register/mviph.rs
@@ -8,7 +8,9 @@ riscv::read_write_csr! {
 
 impl Mviph {
     #[inline]
-    pub const fn raw(self) -> usize { self.bits }
+    pub const fn raw(self) -> usize {
+        self.bits
+    }
 }
 
 #[cfg(test)]

--- a/library/riscv-aia/src/register/mviph.rs
+++ b/library/riscv-aia/src/register/mviph.rs
@@ -5,3 +5,8 @@ riscv::read_write_csr! {
     Mviph: 0x319,
     mask: 0xFFFF_FFFF,
 }
+
+impl Mviph {
+    #[inline]
+    pub const fn raw(self) -> usize { self.bits }
+}

--- a/library/riscv-aia/src/register/mviph.rs
+++ b/library/riscv-aia/src/register/mviph.rs
@@ -10,3 +10,15 @@ impl Mviph {
     #[inline]
     pub const fn raw(self) -> usize { self.bits }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn mviph_raw_roundtrip() {
+        let bits: usize = 0x0F0F0F0Fusize & 0xFFFF_FFFF;
+        let reg = Mviph::from_bits(bits);
+        assert_eq!(reg.raw(), bits);
+    }
+}

--- a/library/riscv-aia/src/register/sie.rs
+++ b/library/riscv-aia/src/register/sie.rs
@@ -1,0 +1,7 @@
+//! Supervisor interrupt-enable bits (sie)
+
+riscv::read_write_csr! {
+    /// Supervisor interrupt-enable bits.
+    Sie: 0x104,
+    mask: 0xFFFF_FFFF_FFFF_FFFF,
+}

--- a/library/riscv-aia/src/register/sie.rs
+++ b/library/riscv-aia/src/register/sie.rs
@@ -25,3 +25,25 @@ impl Sie {
     #[inline]
     pub const fn seip(self) -> bool { self.bit(9) }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sie_bits() {
+        let bits: usize = (1usize << 1) | (1usize << 5) | (1usize << 9);
+        let reg = Sie::from_bits(bits);
+        assert!(reg.ssip());
+        assert!(reg.stip());
+        assert!(reg.seip());
+    }
+
+    #[test]
+    fn sie_zero() {
+        let reg = Sie::from_bits(0);
+        assert!(!reg.ssip());
+        assert!(!reg.stip());
+        assert!(!reg.seip());
+    }
+}

--- a/library/riscv-aia/src/register/sie.rs
+++ b/library/riscv-aia/src/register/sie.rs
@@ -15,15 +15,21 @@ impl Sie {
 
     /// Supervisor software interrupt enable (bit 1).
     #[inline]
-    pub const fn ssip(self) -> bool { self.bit(1) }
+    pub const fn ssip(self) -> bool {
+        self.bit(1)
+    }
 
     /// Supervisor timer interrupt enable (bit 5).
     #[inline]
-    pub const fn stip(self) -> bool { self.bit(5) }
+    pub const fn stip(self) -> bool {
+        self.bit(5)
+    }
 
     /// Supervisor external interrupt enable (bit 9).
     #[inline]
-    pub const fn seip(self) -> bool { self.bit(9) }
+    pub const fn seip(self) -> bool {
+        self.bit(9)
+    }
 }
 
 #[cfg(test)]

--- a/library/riscv-aia/src/register/sie.rs
+++ b/library/riscv-aia/src/register/sie.rs
@@ -5,3 +5,23 @@ riscv::read_write_csr! {
     Sie: 0x104,
     mask: 0xFFFF_FFFF_FFFF_FFFF,
 }
+
+impl Sie {
+    /// Test bit `n` of `sie`.
+    #[inline]
+    pub const fn bit(self, n: usize) -> bool {
+        ((self.bits >> n) & 1) != 0
+    }
+
+    /// Supervisor software interrupt enable (bit 1).
+    #[inline]
+    pub const fn ssip(self) -> bool { self.bit(1) }
+
+    /// Supervisor timer interrupt enable (bit 5).
+    #[inline]
+    pub const fn stip(self) -> bool { self.bit(5) }
+
+    /// Supervisor external interrupt enable (bit 9).
+    #[inline]
+    pub const fn seip(self) -> bool { self.bit(9) }
+}

--- a/library/riscv-aia/src/register/sieh.rs
+++ b/library/riscv-aia/src/register/sieh.rs
@@ -1,0 +1,7 @@
+//! Supervisor interrupt-enable high-half (sieh) (RV32 only)
+
+riscv::read_write_csr! {
+    /// Upper 32 bits of sie (RV32 only).
+    Sieh: 0x114,
+    mask: 0xFFFF_FFFF,
+}

--- a/library/riscv-aia/src/register/sieh.rs
+++ b/library/riscv-aia/src/register/sieh.rs
@@ -10,3 +10,15 @@ impl Sieh {
     #[inline]
     pub const fn raw(self) -> usize { self.bits }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sieh_raw_roundtrip() {
+        let bits: usize = 0xA5A5A5A5usize & 0xFFFF_FFFF;
+        let reg = Sieh::from_bits(bits);
+        assert_eq!(reg.raw(), bits);
+    }
+}

--- a/library/riscv-aia/src/register/sieh.rs
+++ b/library/riscv-aia/src/register/sieh.rs
@@ -8,7 +8,9 @@ riscv::read_write_csr! {
 
 impl Sieh {
     #[inline]
-    pub const fn raw(self) -> usize { self.bits }
+    pub const fn raw(self) -> usize {
+        self.bits
+    }
 }
 
 #[cfg(test)]

--- a/library/riscv-aia/src/register/sieh.rs
+++ b/library/riscv-aia/src/register/sieh.rs
@@ -5,3 +5,8 @@ riscv::read_write_csr! {
     Sieh: 0x114,
     mask: 0xFFFF_FFFF,
 }
+
+impl Sieh {
+    #[inline]
+    pub const fn raw(self) -> usize { self.bits }
+}

--- a/library/riscv-aia/src/register/sip.rs
+++ b/library/riscv-aia/src/register/sip.rs
@@ -15,15 +15,21 @@ impl Sip {
 
     /// Supervisor software interrupt pending (bit 1).
     #[inline]
-    pub const fn ssip(self) -> bool { self.bit(1) }
+    pub const fn ssip(self) -> bool {
+        self.bit(1)
+    }
 
     /// Supervisor timer interrupt pending (bit 5).
     #[inline]
-    pub const fn stip(self) -> bool { self.bit(5) }
+    pub const fn stip(self) -> bool {
+        self.bit(5)
+    }
 
     /// Supervisor external interrupt pending (bit 9).
     #[inline]
-    pub const fn seip(self) -> bool { self.bit(9) }
+    pub const fn seip(self) -> bool {
+        self.bit(9)
+    }
 }
 
 #[cfg(test)]

--- a/library/riscv-aia/src/register/sip.rs
+++ b/library/riscv-aia/src/register/sip.rs
@@ -5,3 +5,23 @@ riscv::read_write_csr! {
     Sip: 0x144,
     mask: 0xFFFF_FFFF_FFFF_FFFF,
 }
+
+impl Sip {
+    /// Test bit `n` of `sip`.
+    #[inline]
+    pub const fn bit(self, n: usize) -> bool {
+        ((self.bits >> n) & 1) != 0
+    }
+
+    /// Supervisor software interrupt pending (bit 1).
+    #[inline]
+    pub const fn ssip(self) -> bool { self.bit(1) }
+
+    /// Supervisor timer interrupt pending (bit 5).
+    #[inline]
+    pub const fn stip(self) -> bool { self.bit(5) }
+
+    /// Supervisor external interrupt pending (bit 9).
+    #[inline]
+    pub const fn seip(self) -> bool { self.bit(9) }
+}

--- a/library/riscv-aia/src/register/sip.rs
+++ b/library/riscv-aia/src/register/sip.rs
@@ -25,3 +25,25 @@ impl Sip {
     #[inline]
     pub const fn seip(self) -> bool { self.bit(9) }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sip_bits() {
+        let bits: usize = (1usize << 1) | (1usize << 5) | (1usize << 9);
+        let reg = Sip::from_bits(bits);
+        assert!(reg.ssip());
+        assert!(reg.stip());
+        assert!(reg.seip());
+    }
+
+    #[test]
+    fn sip_zero() {
+        let reg = Sip::from_bits(0);
+        assert!(!reg.ssip());
+        assert!(!reg.stip());
+        assert!(!reg.seip());
+    }
+}

--- a/library/riscv-aia/src/register/sip.rs
+++ b/library/riscv-aia/src/register/sip.rs
@@ -1,0 +1,7 @@
+//! Supervisor interrupt-pending bits (sip)
+
+riscv::read_write_csr! {
+    /// Supervisor interrupt-pending bits.
+    Sip: 0x144,
+    mask: 0xFFFF_FFFF_FFFF_FFFF,
+}

--- a/library/riscv-aia/src/register/siph.rs
+++ b/library/riscv-aia/src/register/siph.rs
@@ -8,7 +8,9 @@ riscv::read_write_csr! {
 
 impl Siph {
     #[inline]
-    pub const fn raw(self) -> usize { self.bits }
+    pub const fn raw(self) -> usize {
+        self.bits
+    }
 }
 
 #[cfg(test)]

--- a/library/riscv-aia/src/register/siph.rs
+++ b/library/riscv-aia/src/register/siph.rs
@@ -10,3 +10,15 @@ impl Siph {
     #[inline]
     pub const fn raw(self) -> usize { self.bits }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn siph_raw_roundtrip() {
+        let bits: usize = 0x55AA55AAusize & 0xFFFF_FFFF;
+        let reg = Siph::from_bits(bits);
+        assert_eq!(reg.raw(), bits);
+    }
+}

--- a/library/riscv-aia/src/register/siph.rs
+++ b/library/riscv-aia/src/register/siph.rs
@@ -1,0 +1,7 @@
+//! Supervisor interrupt-pending high-half (siph) (RV32 only)
+
+riscv::read_write_csr! {
+    /// Upper 32 bits of sip (RV32 only).
+    Siph: 0x154,
+    mask: 0xFFFF_FFFF,
+}

--- a/library/riscv-aia/src/register/siph.rs
+++ b/library/riscv-aia/src/register/siph.rs
@@ -5,3 +5,8 @@ riscv::read_write_csr! {
     Siph: 0x154,
     mask: 0xFFFF_FFFF,
 }
+
+impl Siph {
+    #[inline]
+    pub const fn raw(self) -> usize { self.bits }
+}

--- a/library/riscv-aia/src/register/sireg.rs
+++ b/library/riscv-aia/src/register/sireg.rs
@@ -1,0 +1,7 @@
+//! Supervisor indirect register alias (sireg)
+
+riscv::read_write_csr! {
+    /// Supervisor indirect register alias.
+    Sireg: 0x151,
+    mask: 0xFFFF_FFFF_FFFF_FFFF,
+}

--- a/library/riscv-aia/src/register/sireg.rs
+++ b/library/riscv-aia/src/register/sireg.rs
@@ -15,3 +15,16 @@ impl Sireg {
     #[inline]
     pub const fn as_usize(self) -> usize { self.bits }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sireg_raw_roundtrip() {
+        let bits: usize = 0x1234_5678usize & 0xFFFF_FFFF_FFFF_FFFF;
+        let reg = Sireg::from_bits(bits);
+        assert_eq!(reg.raw(), bits);
+        assert_eq!(reg.as_usize(), bits);
+    }
+}

--- a/library/riscv-aia/src/register/sireg.rs
+++ b/library/riscv-aia/src/register/sireg.rs
@@ -9,11 +9,15 @@ riscv::read_write_csr! {
 impl Sireg {
     /// Raw bits read from `sireg` (width depends on XLEN).
     #[inline]
-    pub const fn raw(self) -> usize { self.bits }
+    pub const fn raw(self) -> usize {
+        self.bits
+    }
 
     /// Convenience accessor returning bits as usize.
     #[inline]
-    pub const fn as_usize(self) -> usize { self.bits }
+    pub const fn as_usize(self) -> usize {
+        self.bits
+    }
 }
 
 #[cfg(test)]

--- a/library/riscv-aia/src/register/sireg.rs
+++ b/library/riscv-aia/src/register/sireg.rs
@@ -5,3 +5,13 @@ riscv::read_write_csr! {
     Sireg: 0x151,
     mask: 0xFFFF_FFFF_FFFF_FFFF,
 }
+
+impl Sireg {
+    /// Raw bits read from `sireg` (width depends on XLEN).
+    #[inline]
+    pub const fn raw(self) -> usize { self.bits }
+
+    /// Convenience accessor returning bits as usize.
+    #[inline]
+    pub const fn as_usize(self) -> usize { self.bits }
+}

--- a/library/riscv-aia/src/register/siselect.rs
+++ b/library/riscv-aia/src/register/siselect.rs
@@ -9,7 +9,9 @@ riscv::read_write_csr! {
 impl Siselect {
     /// Current value of `siselect` as usize.
     #[inline]
-    pub const fn value(self) -> usize { self.bits as usize }
+    pub const fn value(self) -> usize {
+        self.bits as usize
+    }
 
     // Note: writing to `siselect` should be done via the generated CSR API.
 }

--- a/library/riscv-aia/src/register/siselect.rs
+++ b/library/riscv-aia/src/register/siselect.rs
@@ -1,0 +1,7 @@
+//! Supervisor indirect register select (siselect)
+
+riscv::read_write_csr! {
+    /// Supervisor indirect register select.
+    Siselect: 0x150,
+    mask: 0xFFFF_FFFF_FFFF_FFFF,
+}

--- a/library/riscv-aia/src/register/siselect.rs
+++ b/library/riscv-aia/src/register/siselect.rs
@@ -13,3 +13,15 @@ impl Siselect {
 
     // Note: writing to `siselect` should be done via the generated CSR API.
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn siselect_value() {
+        let sel: usize = 0x42;
+        let reg = Siselect::from_bits(sel);
+        assert_eq!(reg.value(), sel);
+    }
+}

--- a/library/riscv-aia/src/register/siselect.rs
+++ b/library/riscv-aia/src/register/siselect.rs
@@ -5,3 +5,11 @@ riscv::read_write_csr! {
     Siselect: 0x150,
     mask: 0xFFFF_FFFF_FFFF_FFFF,
 }
+
+impl Siselect {
+    /// Current value of `siselect` as usize.
+    #[inline]
+    pub const fn value(self) -> usize { self.bits as usize }
+
+    // Note: writing to `siselect` should be done via the generated CSR API.
+}

--- a/library/riscv-aia/src/register/stopei.rs
+++ b/library/riscv-aia/src/register/stopei.rs
@@ -22,3 +22,18 @@ impl Stopei {
 		(self.bits & 0x0000_00FF) as u8
 	}
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn stopei_parsing() {
+        let iid_num: u16 = 2047; // max allowed
+        let iprio: u8 = 0xFF;
+        let bits: usize = ((iid_num as usize) << 16) | (iprio as usize);
+        let reg = Stopei::from_bits(bits);
+        assert_eq!(reg.iprio(), iprio);
+        assert_eq!(reg.iid().map(|i| i.number()), Some(iid_num));
+    }
+}

--- a/library/riscv-aia/src/register/stopei.rs
+++ b/library/riscv-aia/src/register/stopei.rs
@@ -1,3 +1,24 @@
 //! Supervisor top external interrupt (only with an IMSIC) (stopei)
 
-riscv::read_csr_as_usize!(0x15C);
+use crate::Iid;
+
+riscv::read_only_csr! {
+	/// Supervisor top external interrupt register.
+	Stopei: 0x15C,
+	mask: 0x0FFF_00FF,
+}
+
+impl Stopei {
+	/// Get the major identity number of the highest-priority external interrupt.
+	#[inline]
+	pub const fn iid(self) -> Option<Iid> {
+		let bits = (self.bits & 0x0FFF_0000) >> 16;
+		Iid::new(bits as u16)
+	}
+
+	/// Indicates the priority number of the highest-priority external interrupt.
+	#[inline]
+	pub const fn iprio(self) -> u8 {
+		(self.bits & 0x0000_00FF) as u8
+	}
+}

--- a/library/riscv-aia/src/register/stopei.rs
+++ b/library/riscv-aia/src/register/stopei.rs
@@ -3,24 +3,24 @@
 use crate::Iid;
 
 riscv::read_only_csr! {
-	/// Supervisor top external interrupt register.
-	Stopei: 0x15C,
-	mask: 0x0FFF_00FF,
+    /// Supervisor top external interrupt register.
+    Stopei: 0x15C,
+    mask: 0x0FFF_00FF,
 }
 
 impl Stopei {
-	/// Get the major identity number of the highest-priority external interrupt.
-	#[inline]
-	pub const fn iid(self) -> Option<Iid> {
-		let bits = (self.bits & 0x0FFF_0000) >> 16;
-		Iid::new(bits as u16)
-	}
+    /// Get the major identity number of the highest-priority external interrupt.
+    #[inline]
+    pub const fn iid(self) -> Option<Iid> {
+        let bits = (self.bits & 0x0FFF_0000) >> 16;
+        Iid::new(bits as u16)
+    }
 
-	/// Indicates the priority number of the highest-priority external interrupt.
-	#[inline]
-	pub const fn iprio(self) -> u8 {
-		(self.bits & 0x0000_00FF) as u8
-	}
+    /// Indicates the priority number of the highest-priority external interrupt.
+    #[inline]
+    pub const fn iprio(self) -> u8 {
+        (self.bits & 0x0000_00FF) as u8
+    }
 }
 
 #[cfg(test)]

--- a/library/riscv-aia/src/register/stopei.rs
+++ b/library/riscv-aia/src/register/stopei.rs
@@ -1,0 +1,3 @@
+//! Supervisor top external interrupt (only with an IMSIC) (stopei)
+
+riscv::read_csr_as_usize!(0x15C);

--- a/library/riscv-aia/src/register/stopi.rs
+++ b/library/riscv-aia/src/register/stopi.rs
@@ -1,0 +1,22 @@
+//! Supervisor top interrupt (stopi)
+
+riscv::read_only_csr! {
+    /// Supervisor top interrupt register.
+    Stopi: 0xDB0,
+    mask: 0x0FFF_00FF,
+}
+
+impl Stopi {
+    /// Get the major identity number of the highest-priority interrupt.
+    #[inline]
+    pub const fn iid(self) -> Option<crate::Iid> {
+        let bits = (self.bits & 0x0FFF_0000) >> 16;
+        crate::Iid::new(bits as u16)
+    }
+
+    /// Indicates the priority number of the highest-priority interrupt.
+    #[inline]
+    pub const fn iprio(self) -> u8 {
+        (self.bits & 0x0000_00FF) as u8
+    }
+}

--- a/library/riscv-aia/src/register/stopi.rs
+++ b/library/riscv-aia/src/register/stopi.rs
@@ -20,3 +20,25 @@ impl Stopi {
         (self.bits & 0x0000_00FF) as u8
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn stopi_parsing() {
+        let iid_num: u16 = 0x123;
+        let iprio: u8 = 0x7;
+        let bits: usize = ((iid_num as usize) << 16) | (iprio as usize);
+        let reg = Stopi::from_bits(bits);
+        assert_eq!(reg.iprio(), iprio);
+        assert_eq!(reg.iid().map(|i| i.number()), Some(iid_num));
+    }
+
+    #[test]
+    fn stopi_zero_iid() {
+        let reg = Stopi::from_bits(0);
+        assert!(reg.iid().is_none());
+        assert_eq!(reg.iprio(), 0);
+    }
+}

--- a/library/riscv-aia/src/register/vsie.rs
+++ b/library/riscv-aia/src/register/vsie.rs
@@ -1,0 +1,7 @@
+//! Virtual supervisor interrupt-enable bits (vsie)
+
+riscv::read_write_csr! {
+    /// Virtual supervisor interrupt-enable bits.
+    Vsie: 0x204,
+    mask: 0xFFFF_FFFF_FFFF_FFFF,
+}

--- a/library/riscv-aia/src/register/vsie.rs
+++ b/library/riscv-aia/src/register/vsie.rs
@@ -5,3 +5,23 @@ riscv::read_write_csr! {
     Vsie: 0x204,
     mask: 0xFFFF_FFFF_FFFF_FFFF,
 }
+
+impl Vsie {
+    /// Test bit `n` of `vsie`.
+    #[inline]
+    pub const fn bit(self, n: usize) -> bool {
+        ((self.bits >> n) & 1) != 0
+    }
+
+    /// VS-level software interrupt enable (bit 2).
+    #[inline]
+    pub const fn vssip(self) -> bool { self.bit(2) }
+
+    /// VS-level timer interrupt enable (bit 6).
+    #[inline]
+    pub const fn vstip(self) -> bool { self.bit(6) }
+
+    /// VS-level external interrupt enable (bit 10).
+    #[inline]
+    pub const fn vseip(self) -> bool { self.bit(10) }
+}

--- a/library/riscv-aia/src/register/vsie.rs
+++ b/library/riscv-aia/src/register/vsie.rs
@@ -15,15 +15,21 @@ impl Vsie {
 
     /// VS-level software interrupt enable (bit 2).
     #[inline]
-    pub const fn vssip(self) -> bool { self.bit(2) }
+    pub const fn vssip(self) -> bool {
+        self.bit(2)
+    }
 
     /// VS-level timer interrupt enable (bit 6).
     #[inline]
-    pub const fn vstip(self) -> bool { self.bit(6) }
+    pub const fn vstip(self) -> bool {
+        self.bit(6)
+    }
 
     /// VS-level external interrupt enable (bit 10).
     #[inline]
-    pub const fn vseip(self) -> bool { self.bit(10) }
+    pub const fn vseip(self) -> bool {
+        self.bit(10)
+    }
 }
 
 #[cfg(test)]

--- a/library/riscv-aia/src/register/vsie.rs
+++ b/library/riscv-aia/src/register/vsie.rs
@@ -25,3 +25,23 @@ impl Vsie {
     #[inline]
     pub const fn vseip(self) -> bool { self.bit(10) }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::register::vsip::Vsip;
+
+    #[test]
+    fn vsie_vsip_parsing_bits() {
+        // set vssip (bit 2), vstip (bit 6), vseip (bit 10)
+        let bits: usize = (1usize << 2) | (1usize << 6) | (1usize << 10);
+        let en = Vsie::from_bits(bits);
+        let pend = Vsip::from_bits(bits);
+        assert!(en.vssip());
+        assert!(en.vstip());
+        assert!(en.vseip());
+        assert!(pend.vssip());
+        assert!(pend.vstip());
+        assert!(pend.vseip());
+    }
+}

--- a/library/riscv-aia/src/register/vsieh.rs
+++ b/library/riscv-aia/src/register/vsieh.rs
@@ -1,0 +1,7 @@
+//! Virtual supervisor interrupt-enable high-half (vsieh) (RV32 only)
+
+riscv::read_write_csr! {
+    /// Upper 32 bits of vsie.
+    Vsieh: 0x214,
+    mask: 0xFFFF_FFFF,
+}

--- a/library/riscv-aia/src/register/vsieh.rs
+++ b/library/riscv-aia/src/register/vsieh.rs
@@ -10,3 +10,18 @@ impl Vsieh {
     #[inline]
     pub const fn raw(self) -> usize { self.bits }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::register::vsiph::Vsiph;
+
+    #[test]
+    fn vsieh_vsiph_raw_roundtrip() {
+        let bits: usize = 0x8765_4321usize & 0xFFFF_FFFF;
+        let e = Vsieh::from_bits(bits);
+        let p = Vsiph::from_bits(bits);
+        assert_eq!(e.raw(), bits);
+        assert_eq!(p.raw(), bits);
+    }
+}

--- a/library/riscv-aia/src/register/vsieh.rs
+++ b/library/riscv-aia/src/register/vsieh.rs
@@ -5,3 +5,8 @@ riscv::read_write_csr! {
     Vsieh: 0x214,
     mask: 0xFFFF_FFFF,
 }
+
+impl Vsieh {
+    #[inline]
+    pub const fn raw(self) -> usize { self.bits }
+}

--- a/library/riscv-aia/src/register/vsieh.rs
+++ b/library/riscv-aia/src/register/vsieh.rs
@@ -8,7 +8,9 @@ riscv::read_write_csr! {
 
 impl Vsieh {
     #[inline]
-    pub const fn raw(self) -> usize { self.bits }
+    pub const fn raw(self) -> usize {
+        self.bits
+    }
 }
 
 #[cfg(test)]

--- a/library/riscv-aia/src/register/vsip.rs
+++ b/library/riscv-aia/src/register/vsip.rs
@@ -1,0 +1,7 @@
+//! Virtual supervisor interrupt-pending bits (vsip)
+
+riscv::read_write_csr! {
+    /// Virtual supervisor interrupt-pending bits.
+    Vsip: 0x244,
+    mask: 0xFFFF_FFFF_FFFF_FFFF,
+}

--- a/library/riscv-aia/src/register/vsip.rs
+++ b/library/riscv-aia/src/register/vsip.rs
@@ -5,3 +5,23 @@ riscv::read_write_csr! {
     Vsip: 0x244,
     mask: 0xFFFF_FFFF_FFFF_FFFF,
 }
+
+impl Vsip {
+    /// Test bit `n` of `vsip`.
+    #[inline]
+    pub const fn bit(self, n: usize) -> bool {
+        ((self.bits >> n) & 1) != 0
+    }
+
+    /// VS-level software interrupt pending (bit 2).
+    #[inline]
+    pub const fn vssip(self) -> bool { self.bit(2) }
+
+    /// VS-level timer interrupt pending (bit 6).
+    #[inline]
+    pub const fn vstip(self) -> bool { self.bit(6) }
+
+    /// VS-level external interrupt pending (bit 10).
+    #[inline]
+    pub const fn vseip(self) -> bool { self.bit(10) }
+}

--- a/library/riscv-aia/src/register/vsip.rs
+++ b/library/riscv-aia/src/register/vsip.rs
@@ -15,15 +15,21 @@ impl Vsip {
 
     /// VS-level software interrupt pending (bit 2).
     #[inline]
-    pub const fn vssip(self) -> bool { self.bit(2) }
+    pub const fn vssip(self) -> bool {
+        self.bit(2)
+    }
 
     /// VS-level timer interrupt pending (bit 6).
     #[inline]
-    pub const fn vstip(self) -> bool { self.bit(6) }
+    pub const fn vstip(self) -> bool {
+        self.bit(6)
+    }
 
     /// VS-level external interrupt pending (bit 10).
     #[inline]
-    pub const fn vseip(self) -> bool { self.bit(10) }
+    pub const fn vseip(self) -> bool {
+        self.bit(10)
+    }
 }
 
 #[cfg(test)]

--- a/library/riscv-aia/src/register/vsip.rs
+++ b/library/riscv-aia/src/register/vsip.rs
@@ -25,3 +25,23 @@ impl Vsip {
     #[inline]
     pub const fn vseip(self) -> bool { self.bit(10) }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::register::vsie::Vsie;
+
+    #[test]
+    fn vsie_vsip_parsing_bits() {
+        // set vssip (bit 2), vstip (bit 6), vseip (bit 10)
+        let bits: usize = (1usize << 2) | (1usize << 6) | (1usize << 10);
+        let en = Vsie::from_bits(bits);
+        let pend = Vsip::from_bits(bits);
+        assert!(en.vssip());
+        assert!(en.vstip());
+        assert!(en.vseip());
+        assert!(pend.vssip());
+        assert!(pend.vstip());
+        assert!(pend.vseip());
+    }
+}

--- a/library/riscv-aia/src/register/vsiph.rs
+++ b/library/riscv-aia/src/register/vsiph.rs
@@ -10,3 +10,18 @@ impl Vsiph {
     #[inline]
     pub const fn raw(self) -> usize { self.bits }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::register::vsieh::Vsieh;
+
+    #[test]
+    fn vsieh_vsiph_raw_roundtrip() {
+        let bits: usize = 0x8765_4321usize & 0xFFFF_FFFF;
+        let e = Vsieh::from_bits(bits);
+        let p = Vsiph::from_bits(bits);
+        assert_eq!(e.raw(), bits);
+        assert_eq!(p.raw(), bits);
+    }
+}

--- a/library/riscv-aia/src/register/vsiph.rs
+++ b/library/riscv-aia/src/register/vsiph.rs
@@ -1,0 +1,7 @@
+//! Virtual supervisor interrupt-pending high-half (vsiph) (RV32 only)
+
+riscv::read_write_csr! {
+    /// Upper 32 bits of vsip.
+    Vsiph: 0x254,
+    mask: 0xFFFF_FFFF,
+}

--- a/library/riscv-aia/src/register/vsiph.rs
+++ b/library/riscv-aia/src/register/vsiph.rs
@@ -5,3 +5,8 @@ riscv::read_write_csr! {
     Vsiph: 0x254,
     mask: 0xFFFF_FFFF,
 }
+
+impl Vsiph {
+    #[inline]
+    pub const fn raw(self) -> usize { self.bits }
+}

--- a/library/riscv-aia/src/register/vsiph.rs
+++ b/library/riscv-aia/src/register/vsiph.rs
@@ -8,7 +8,9 @@ riscv::read_write_csr! {
 
 impl Vsiph {
     #[inline]
-    pub const fn raw(self) -> usize { self.bits }
+    pub const fn raw(self) -> usize {
+        self.bits
+    }
 }
 
 #[cfg(test)]

--- a/library/riscv-aia/src/register/vsireg.rs
+++ b/library/riscv-aia/src/register/vsireg.rs
@@ -1,0 +1,7 @@
+//! Virtual supervisor indirect register alias (vsireg)
+
+riscv::read_write_csr! {
+    /// Virtual supervisor indirect register alias.
+    Vsireg: 0x251,
+    mask: 0xFFFF_FFFF_FFFF_FFFF,
+}

--- a/library/riscv-aia/src/register/vsireg.rs
+++ b/library/riscv-aia/src/register/vsireg.rs
@@ -5,3 +5,13 @@ riscv::read_write_csr! {
     Vsireg: 0x251,
     mask: 0xFFFF_FFFF_FFFF_FFFF,
 }
+
+impl Vsireg {
+    /// Raw bits read from `vsireg` (width depends on XLEN).
+    #[inline]
+    pub const fn raw(self) -> usize { self.bits }
+
+    /// Convenience accessor returning bits as usize.
+    #[inline]
+    pub const fn as_usize(self) -> usize { self.bits }
+}

--- a/library/riscv-aia/src/register/vsireg.rs
+++ b/library/riscv-aia/src/register/vsireg.rs
@@ -15,3 +15,16 @@ impl Vsireg {
     #[inline]
     pub const fn as_usize(self) -> usize { self.bits }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn vsireg_raw_roundtrip() {
+        let bits: usize = 0xABCD_EF01usize & 0xFFFF_FFFF_FFFF_FFFF;
+        let reg = Vsireg::from_bits(bits);
+        assert_eq!(reg.raw(), bits);
+        assert_eq!(reg.as_usize(), bits);
+    }
+}

--- a/library/riscv-aia/src/register/vsireg.rs
+++ b/library/riscv-aia/src/register/vsireg.rs
@@ -9,11 +9,15 @@ riscv::read_write_csr! {
 impl Vsireg {
     /// Raw bits read from `vsireg` (width depends on XLEN).
     #[inline]
-    pub const fn raw(self) -> usize { self.bits }
+    pub const fn raw(self) -> usize {
+        self.bits
+    }
 
     /// Convenience accessor returning bits as usize.
     #[inline]
-    pub const fn as_usize(self) -> usize { self.bits }
+    pub const fn as_usize(self) -> usize {
+        self.bits
+    }
 }
 
 #[cfg(test)]

--- a/library/riscv-aia/src/register/vsiselect.rs
+++ b/library/riscv-aia/src/register/vsiselect.rs
@@ -9,7 +9,9 @@ riscv::read_write_csr! {
 impl Vsiselect {
     /// Current value of `vsiselect` as usize.
     #[inline]
-    pub const fn value(self) -> usize { self.bits as usize }
+    pub const fn value(self) -> usize {
+        self.bits as usize
+    }
 
     // Note: writing to `vsiselect` should be done via the generated CSR API.
 }

--- a/library/riscv-aia/src/register/vsiselect.rs
+++ b/library/riscv-aia/src/register/vsiselect.rs
@@ -13,3 +13,15 @@ impl Vsiselect {
 
     // Note: writing to `vsiselect` should be done via the generated CSR API.
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn vsiselect_value() {
+        let sel: usize = 0x99;
+        let reg = Vsiselect::from_bits(sel);
+        assert_eq!(reg.value(), sel);
+    }
+}

--- a/library/riscv-aia/src/register/vsiselect.rs
+++ b/library/riscv-aia/src/register/vsiselect.rs
@@ -5,3 +5,11 @@ riscv::read_write_csr! {
     Vsiselect: 0x250,
     mask: 0xFFFF_FFFF_FFFF_FFFF,
 }
+
+impl Vsiselect {
+    /// Current value of `vsiselect` as usize.
+    #[inline]
+    pub const fn value(self) -> usize { self.bits as usize }
+
+    // Note: writing to `vsiselect` should be done via the generated CSR API.
+}

--- a/library/riscv-aia/src/register/vsiselect.rs
+++ b/library/riscv-aia/src/register/vsiselect.rs
@@ -1,0 +1,7 @@
+//! Virtual supervisor indirect register select (vsiselect)
+
+riscv::read_write_csr! {
+    /// Virtual supervisor indirect register select.
+    Vsiselect: 0x250,
+    mask: 0xFFFF_FFFF_FFFF_FFFF,
+}

--- a/library/riscv-aia/src/register/vstopei.rs
+++ b/library/riscv-aia/src/register/vstopei.rs
@@ -1,3 +1,24 @@
 //! Virtual supervisor top external interrupt (only with an IMSIC) (vstopei)
 
-riscv::read_csr_as_usize!(0x25C);
+use crate::Iid;
+
+riscv::read_only_csr! {
+	/// Virtual supervisor top external interrupt register.
+	Vstopei: 0x25C,
+	mask: 0x0FFF_00FF,
+}
+
+impl Vstopei {
+	/// Get the major identity number of the highest-priority external interrupt.
+	#[inline]
+	pub const fn iid(self) -> Option<Iid> {
+		let bits = (self.bits & 0x0FFF_0000) >> 16;
+		Iid::new(bits as u16)
+	}
+
+	/// Indicates the priority number of the highest-priority external interrupt.
+	#[inline]
+	pub const fn iprio(self) -> u8 {
+		(self.bits & 0x0000_00FF) as u8
+	}
+}

--- a/library/riscv-aia/src/register/vstopei.rs
+++ b/library/riscv-aia/src/register/vstopei.rs
@@ -1,0 +1,3 @@
+//! Virtual supervisor top external interrupt (only with an IMSIC) (vstopei)
+
+riscv::read_csr_as_usize!(0x25C);

--- a/library/riscv-aia/src/register/vstopei.rs
+++ b/library/riscv-aia/src/register/vstopei.rs
@@ -3,24 +3,24 @@
 use crate::Iid;
 
 riscv::read_only_csr! {
-	/// Virtual supervisor top external interrupt register.
-	Vstopei: 0x25C,
-	mask: 0x0FFF_00FF,
+    /// Virtual supervisor top external interrupt register.
+    Vstopei: 0x25C,
+    mask: 0x0FFF_00FF,
 }
 
 impl Vstopei {
-	/// Get the major identity number of the highest-priority external interrupt.
-	#[inline]
-	pub const fn iid(self) -> Option<Iid> {
-		let bits = (self.bits & 0x0FFF_0000) >> 16;
-		Iid::new(bits as u16)
-	}
+    /// Get the major identity number of the highest-priority external interrupt.
+    #[inline]
+    pub const fn iid(self) -> Option<Iid> {
+        let bits = (self.bits & 0x0FFF_0000) >> 16;
+        Iid::new(bits as u16)
+    }
 
-	/// Indicates the priority number of the highest-priority external interrupt.
-	#[inline]
-	pub const fn iprio(self) -> u8 {
-		(self.bits & 0x0000_00FF) as u8
-	}
+    /// Indicates the priority number of the highest-priority external interrupt.
+    #[inline]
+    pub const fn iprio(self) -> u8 {
+        (self.bits & 0x0000_00FF) as u8
+    }
 }
 
 #[cfg(test)]

--- a/library/riscv-aia/src/register/vstopei.rs
+++ b/library/riscv-aia/src/register/vstopei.rs
@@ -22,3 +22,17 @@ impl Vstopei {
 		(self.bits & 0x0000_00FF) as u8
 	}
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn vstopei_parsing_none() {
+        // zero iid should yield None
+        let bits: usize = 0; // iid==0, iprio==0
+        let reg = Vstopei::from_bits(bits);
+        assert_eq!(reg.iprio(), 0);
+        assert!(reg.iid().is_none());
+    }
+}

--- a/library/riscv-aia/src/register/vstopi.rs
+++ b/library/riscv-aia/src/register/vstopi.rs
@@ -18,3 +18,25 @@ impl Vstopi {
         (self.bits & 0x0000_00FF) as u8
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn vstopi_parsing() {
+        let iid_num: u16 = 0x456;
+        let iprio: u8 = 0xFF;
+        let bits: usize = ((iid_num as usize) << 16) | (iprio as usize);
+        let reg = Vstopi::from_bits(bits);
+        assert_eq!(reg.iprio(), iprio);
+        assert_eq!(reg.iid().map(|i| i.number()), Some(iid_num));
+    }
+
+    #[test]
+    fn vstopi_zero_iid() {
+        let reg = Vstopi::from_bits(0);
+        assert!(reg.iid().is_none());
+        assert_eq!(reg.iprio(), 0);
+    }
+}

--- a/library/riscv-aia/src/register/vstopi.rs
+++ b/library/riscv-aia/src/register/vstopi.rs
@@ -1,0 +1,20 @@
+//! Virtual supervisor top interrupt (vstopi)
+
+riscv::read_only_csr! {
+    /// Virtual supervisor top interrupt register.
+    Vstopi: 0xEB0,
+    mask: 0x0FFF_00FF,
+}
+
+impl Vstopi {
+    #[inline]
+    pub const fn iid(self) -> Option<crate::Iid> {
+        let bits = (self.bits & 0x0FFF_0000) >> 16;
+        crate::Iid::new(bits as u16)
+    }
+
+    #[inline]
+    pub const fn iprio(self) -> u8 {
+        (self.bits & 0x0000_00FF) as u8
+    }
+}


### PR DESCRIPTION
Added individual modules for all RISC-V Advanced Interrupt Architecture (AIA) control and status registers (CSRs), including machine, supervisor, hypervisor, and virtual supervisor levels. Updated register.rs to enable these modules, providing direct access to all relevant interrupt delegation, enable, pending, priority, and indirect registers for AIA support.

Signed-off-by: Killy Jack <zicai@openatom.club><details>
<summary>📝 <strong>Click for commit rules checklist / 点击查看提交规范检查表</strong></summary>

- [![Commit Rules (EN)](https://img.shields.io/badge/Commit%20Rules-Important!-brightgreen?style=flat&logo=git)](https://github.com/rustsbi/slides/blob/main/2025/reports/Contributing%20to%20RustSBI.md)
- [![Commit Rules (ZH)](https://img.shields.io/badge/查看提交规范-重要!-brightgreen?style=flat&logo=git)](https://github.com/rustsbi/slides/blob/main/2025/reports/%E4%B8%BA%20RustSBI%20%E8%B4%A1%E7%8C%AE.md)

</details>
